### PR TITLE
[#2164][#2123][#2613][#2124][#2625] test: 배송 완료 시 알림 발송 연동 기능 자동화 테스트 추가 / 배송 완료 시 인앱 알림 생성 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationRequestNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationRequestNotificationConsumer.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PurchaseConfirmationRequestNotificationConsumer {
+
+    private static final String DELIVERED_STATUS = "DELIVERED";
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SHIPPING_STATUS_CHANGED,
+            groupId = "notification-purchase-confirmation"
+    )
+    public void handleShippingStatusChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SHIPPING_STATUS_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ShippingStatusChangedEvent payload = envelope.getPayloadAs(ShippingStatusChangedEvent.class, objectMapper);
+
+        if (!DELIVERED_STATUS.equals(payload.shippingStatus())) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.info("배송 완료 이벤트 수신 (구매 확정 요청 알림 예약). eventId={}, orderId={}, buyerId={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (FormatValidator.hasNoValue(payload.occurredAt())) {
+            log.warn("occurredAt이 null입니다. eventId={}", envelope.eventId());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            LocalDateTime scheduledAt = payload.occurredAt().plusDays(1);
+
+            SendNotificationCommand command = new SendNotificationCommand(
+                    payload.buyerId(),
+                    "PURCHASE_CONFIRMATION_REQUEST",
+                    Map.of("order_id", String.valueOf(payload.orderId())),
+                    "PUSH_AND_IN_APP",
+                    scheduledAt
+            );
+            sendNotificationUseCase.sendNotification(command);
+
+            log.info("구매 확정 요청 알림 예약 완료. orderId={}, buyerId={}, scheduledAt={}",
+                    payload.orderId(), payload.buyerId(), scheduledAt);
+        } catch (Exception e) {
+            log.error("구매 확정 요청 알림 발송 실패. eventId={}, orderId={}, buyerId={}, error={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), e.getMessage(), e);
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/ShippingCompletedNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/ShippingCompletedNotificationConsumer.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShippingCompletedNotificationConsumer {
+
+    private static final String DELIVERED_STATUS = "DELIVERED";
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SHIPPING_STATUS_CHANGED,
+            groupId = "notification-shipping"
+    )
+    public void handleShippingStatusChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SHIPPING_STATUS_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ShippingStatusChangedEvent payload = envelope.getPayloadAs(ShippingStatusChangedEvent.class, objectMapper);
+
+        if (!DELIVERED_STATUS.equals(payload.shippingStatus())) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.info("배송 완료 이벤트 수신 (알림 발송). eventId={}, orderId={}, buyerId={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            SendNotificationCommand command = new SendNotificationCommand(
+                    payload.buyerId(),
+                    "SHIPPING_COMPLETED",
+                    Map.of("order_id", String.valueOf(payload.orderId())),
+                    "PUSH_AND_IN_APP",
+                    null
+            );
+            sendNotificationUseCase.sendNotification(command);
+
+            log.info("배송 완료 알림 발송 완료. orderId={}, buyerId={}", payload.orderId(), payload.buyerId());
+        } catch (Exception e) {
+            log.error("배송 완료 알림 발송 실패. eventId={}, orderId={}, buyerId={}, error={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), e.getMessage(), e);
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/in/event/ShippingCompletedNotificationConsumerTest.java
+++ b/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/in/event/ShippingCompletedNotificationConsumerTest.java
@@ -1,0 +1,187 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ShippingCompletedNotificationConsumerTest {
+
+    @InjectMocks
+    private ShippingCompletedNotificationConsumer consumer;
+
+    @Mock
+    private SendNotificationUseCase sendNotificationUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(
+            Long orderId, Long buyerId, String shippingStatus) {
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                orderId, buyerId, shippingStatus, "TRACK-001", "CJ",
+                LocalDateTime.of(2026, 4, 10, 15, 0)
+        );
+        EventEnvelope<ShippingStatusChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "fulfillment.shipping.status-changed", "fulfillment-service",
+                LocalDateTime.of(2026, 4, 10, 15, 0), event
+        );
+        return new ConsumerRecord<>("fulfillment.shipping.status-changed", 0, 0L,
+                String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("배송 상태 DELIVERED 이벤트 수신 시 SendNotificationUseCase를 호출하고 acknowledge한다")
+    void shouldSendNotificationAndAcknowledgeWhenDeliveredStatus() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, 1L, "DELIVERED");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<SendNotificationCommand> captor = ArgumentCaptor.forClass(SendNotificationCommand.class);
+        verify(sendNotificationUseCase).sendNotification(captor.capture());
+
+        SendNotificationCommand command = captor.getValue();
+        assertThat(command.userId()).isEqualTo(1L);
+        assertThat(command.templateCode()).isEqualTo("SHIPPING_COMPLETED");
+        assertThat(command.deliveryChannel()).isEqualTo("PUSH_AND_IN_APP");
+        assertThat(command.variables()).containsEntry("order_id", "100");
+        assertThat(command.scheduledAt()).isNull();
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("배송 상태 SHIPPING 이벤트 수신 시 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenShippingStatus() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, 1L, "SHIPPING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("배송 상태 PREPARING 이벤트 수신 시 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenPreparingStatus() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, 1L, "PREPARING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenEnvelopeIsNull() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "fulfillment.shipping.status-changed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenEventTypeMismatch() {
+        // given
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                100L, 1L, "DELIVERED", "TRACK-001", "CJ",
+                LocalDateTime.of(2026, 4, 10, 15, 0)
+        );
+        EventEnvelope<ShippingStatusChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "fulfillment-service",
+                LocalDateTime.of(2026, 4, 10, 15, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "fulfillment.shipping.status-changed", 0, 0L, "100", envelope
+        );
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenBuyerIdIsNull() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, null, "DELIVERED");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenOrderIdIsNull() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 1L, "DELIVERED");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("알림 발송 중 예외가 발생해도 acknowledge한다")
+    void shouldAcknowledgeWhenSendNotificationFails() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, 1L, "DELIVERED");
+        doThrow(new RuntimeException("FCM 발송 실패"))
+                .when(sendNotificationUseCase).sendNotification(any(SendNotificationCommand.class));
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verify(sendNotificationUseCase).sendNotification(any(SendNotificationCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2613
## partially addresses #2124
## resolves #2625

## Test Case
- [x] 배송 상태 DELIVERED 이벤트 수신 시 SendNotificationUseCase를 호출하고 acknowledge한다
- [x] 배송 상태 SHIPPING 이벤트 수신 시 알림을 발송하지 않고 acknowledge한다
- [x] 배송 상태 PREPARING 이벤트 수신 시 알림을 발송하지 않고 acknowledge한다
- [x] envelope이 null이면 알림을 발송하지 않고 acknowledge한다
- [x] eventType이 불일치하면 알림을 발송하지 않고 acknowledge한다
- [x] buyerId가 null이면 알림을 발송하지 않고 acknowledge한다
- [x] orderId가 null이면 알림을 발송하지 않고 acknowledge한다
- [x] 알림 발송 중 예외가 발생해도 acknowledge한다
