### PR TITLE
[#2164][#2123][#2103] feat: 포인트 적립 시 알림 발송 연동 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -57,6 +57,9 @@ public final class KafkaTopicConstants {
     // Fulfillment 이벤트
     public static final String SHIPPING_STATUS_CHANGED = "fulfillment.shipping.status-changed";
 
+    // Reward 이벤트
+    public static final String POINT_ACCRUED = "reward.point.accrued";
+
     // Dead Letter Topic 접미사
     public static final String DLT_SUFFIX = ".dlt";
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PointAccruedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PointAccruedEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record PointAccruedEvent(
+        Long userId,
+        Long amount
+) {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/PointAccruedNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/PointAccruedNotificationConsumer.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.PointAccruedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointAccruedNotificationConsumer {
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.POINT_ACCRUED,
+            groupId = "notification-point-accrued"
+    )
+    public void handlePointAccruedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.POINT_ACCRUED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        PointAccruedEvent payload = envelope.getPayloadAs(PointAccruedEvent.class, objectMapper);
+
+        log.info("포인트 적립 이벤트 수신 (알림 발송). eventId={}, userId={}, amount={}",
+                envelope.eventId(), payload.userId(), payload.amount());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("userId", payload.userId()),
+                EventPayloadValidator.id("amount", payload.amount()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SendNotificationCommand command = new SendNotificationCommand(
+                payload.userId(),
+                "POINT_ACCRUAL",
+                Map.of("amount", String.valueOf(payload.amount())),
+                "PUSH_ONLY",
+                null
+        );
+        sendNotificationUseCase.sendNotification(command);
+
+        log.info("포인트 적립 알림 발송 완료. userId={}, amount={}", payload.userId(), payload.amount());
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2103

## Task
- [x] KafkaTopicConstants에 POINT_ACCRUED = "reward.point.accrued" 상수 추가
- [x] PointAccruedEvent record 생성 (userId, amount)
- [x] PointAccruedNotificationConsumer 생성 (groupId: notification-point-accrued, deliveryChannel: PUSH_ONLY, templateCode: POINT_ACCRUAL)
