### PR TITLE
[#2164][#2123][#2527][#2124][#2131] feat: 배송 지연 시 푸시 알림 발송 기능 추가 / 배송 지연 시 인앱 알림 생성 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/ShippingDelayedNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/ShippingDelayedNotificationConsumer.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShippingDelayedNotificationConsumer {
+
+    private static final String DELIVERY_FAILED_STATUS = "DELIVERY_FAILED";
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SHIPPING_STATUS_CHANGED,
+            groupId = "notification-shipping"
+    )
+    public void handleShippingStatusChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SHIPPING_STATUS_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ShippingStatusChangedEvent payload = envelope.getPayloadAs(ShippingStatusChangedEvent.class, objectMapper);
+
+        if (!DELIVERY_FAILED_STATUS.equals(payload.shippingStatus())) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.info("배송 지연 이벤트 수신 (알림 발송). eventId={}, orderId={}, buyerId={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            SendNotificationCommand command = new SendNotificationCommand(
+                    payload.buyerId(),
+                    "SHIPPING_DELAYED",
+                    Map.of("order_id", String.valueOf(payload.orderId())),
+                    "PUSH_AND_IN_APP",
+                    null
+            );
+            sendNotificationUseCase.sendNotification(command);
+
+            log.info("배송 지연 알림 발송 완료. orderId={}, buyerId={}", payload.orderId(), payload.buyerId());
+        } catch (Exception e) {
+            log.error("배송 지연 알림 발송 실패. eventId={}, orderId={}, buyerId={}, error={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), e.getMessage(), e);
+        }
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2527
## partially addresses #2124
## resolves #2131

## Task
- [x] ShippingDelayedNotificationConsumer 신규 작성 (DELIVERY_FAILED 상태 필터링, PUSH_AND_IN_APP)
- [x] try-catch로 sendNotification 감싸서 실패 시에도 acknowledge 보장
