### PR TITLE
[#2164][#2123][#2106] feat: 대량 알림 발송 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
@@ -5,13 +5,21 @@ import com.personal.marketnote.notification.domain.device.Platform;
 import com.personal.marketnote.notification.domain.notification.FcmSendFailedException;
 import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
 import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
+import com.personal.marketnote.notification.port.out.result.SendBatchPushNotificationResult;
 import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 public class FcmPushNotificationClient implements SendPushNotificationPort {
+
+    private static final int BATCH_CHUNK_SIZE = 500;
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final long INITIAL_BACKOFF_MS = 1000L;
 
     private final FirebaseMessaging firebaseMessaging;
 
@@ -81,5 +89,85 @@ public class FcmPushNotificationClient implements SendPushNotificationPort {
     private boolean isTokenInvalid(MessagingErrorCode errorCode) {
         return errorCode == MessagingErrorCode.UNREGISTERED
                 || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
+    }
+
+    @Override
+    public SendBatchPushNotificationResult sendBatch(List<SendPushNotificationCommand> commands) {
+        int totalSuccess = 0;
+        int totalFailure = 0;
+        List<SendBatchPushNotificationResult.FailedToken> allFailedTokens = new ArrayList<>();
+
+        for (int i = 0; i < commands.size(); i += BATCH_CHUNK_SIZE) {
+            int end = Math.min(i + BATCH_CHUNK_SIZE, commands.size());
+            List<SendPushNotificationCommand> chunk = commands.subList(i, end);
+
+            List<Message> messages = chunk.stream()
+                    .map(this::buildMessage)
+                    .toList();
+
+            BatchResponse response = sendWithRetry(messages);
+            if (response == null) {
+                totalFailure += chunk.size();
+                for (SendPushNotificationCommand cmd : chunk) {
+                    allFailedTokens.add(new SendBatchPushNotificationResult.FailedToken(
+                            cmd.deviceToken(), "BATCH_SEND_FAILED", false));
+                }
+                continue;
+            }
+
+            totalSuccess += response.getSuccessCount();
+            totalFailure += response.getFailureCount();
+
+            List<SendResponse> responses = response.getResponses();
+            for (int j = 0; j < responses.size(); j++) {
+                SendResponse sendResponse = responses.get(j);
+                if (sendResponse.isSuccessful()) {
+                    continue;
+                }
+                FirebaseMessagingException exception = sendResponse.getException();
+                MessagingErrorCode errorCode = exception != null ? exception.getMessagingErrorCode() : null;
+                String errorCodeName = errorCode != null ? errorCode.name() : "UNKNOWN";
+                allFailedTokens.add(new SendBatchPushNotificationResult.FailedToken(
+                        chunk.get(j).deviceToken(), errorCodeName, isTokenInvalid(errorCode)));
+            }
+        }
+
+        log.info("FCM 대량 발송 완료: 성공={}, 실패={}", totalSuccess, totalFailure);
+        return new SendBatchPushNotificationResult(totalSuccess, totalFailure, allFailedTokens);
+    }
+
+    private BatchResponse sendWithRetry(List<Message> messages) {
+        long backoffMs = INITIAL_BACKOFF_MS;
+        for (int attempt = 0; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+            if (Thread.currentThread().isInterrupted()) {
+                log.warn("FCM 대량 발송 재시도 중 인터럽트 감지, 중단");
+                return null;
+            }
+            try {
+                return firebaseMessaging.sendEach(messages);
+            } catch (FirebaseMessagingException fme) {
+                if (fme.getMessagingErrorCode() != MessagingErrorCode.QUOTA_EXCEEDED) {
+                    log.error("FCM 대량 발송 실패 (재시도 불가): errorCode={}", fme.getMessagingErrorCode());
+                    return null;
+                }
+                if (attempt == MAX_RETRY_ATTEMPTS) {
+                    log.error("FCM 대량 발송 재시도 횟수 초과: attempts={}", MAX_RETRY_ATTEMPTS);
+                    return null;
+                }
+                log.warn("FCM 429 QUOTA_EXCEEDED, {}ms 후 재시도 (attempt={})", backoffMs, attempt + 1);
+                sleep(backoffMs);
+                backoffMs *= 2;
+            }
+        }
+        return null;
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new FcmSendFailedException("FCM 재시도 중 인터럽트 발생");
+        }
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/DeviceTokenPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/DeviceTokenPersistenceAdapter.java
@@ -33,6 +33,13 @@ public class DeviceTokenPersistenceAdapter
     }
 
     @Override
+    public List<DeviceToken> findActiveByUserIds(List<Long> userIds) {
+        return deviceTokenJpaRepository.findByUserIdInAndStatus(userIds, EntityStatus.ACTIVE).stream()
+                .flatMap(entity -> DeviceTokenJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
+    }
+
+    @Override
     public Optional<DeviceToken> findActiveByDeviceId(String deviceId) {
         return deviceTokenJpaRepository.findByDeviceIdAndStatus(deviceId, EntityStatus.ACTIVE)
                 .flatMap(DeviceTokenJpaEntityToDomainMapper::mapToDomain);

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/repository/DeviceTokenJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/repository/DeviceTokenJpaRepository.java
@@ -12,4 +12,6 @@ public interface DeviceTokenJpaRepository extends JpaRepository<DeviceTokenJpaEn
     Optional<DeviceTokenJpaEntity> findByDeviceIdAndStatus(String deviceId, EntityStatus status);
 
     List<DeviceTokenJpaEntity> findByUserIdAndStatus(Long userId, EntityStatus status);
+
+    List<DeviceTokenJpaEntity> findByUserIdInAndStatus(List<Long> userIds, EntityStatus status);
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -14,7 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -50,6 +52,17 @@ public class NotificationPersistenceAdapter implements FindNotificationPort, Sav
     }
 
     @Override
+    public List<Notification> saveAll(List<Notification> notifications) {
+        List<NotificationJpaEntity> entities = notifications.stream()
+                .map(NotificationJpaEntity::from)
+                .toList();
+        List<NotificationJpaEntity> savedEntities = notificationJpaRepository.saveAll(entities);
+        return savedEntities.stream()
+                .flatMap(entity -> NotificationJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
+    }
+
+    @Override
     public Notification save(Notification notification) {
         NotificationJpaEntity entity = NotificationJpaEntity.from(notification);
         NotificationJpaEntity saved = notificationJpaRepository.save(entity);
@@ -61,5 +74,19 @@ public class NotificationPersistenceAdapter implements FindNotificationPort, Sav
         NotificationJpaEntity entity = notificationJpaRepository.findById(notification.getId())
                 .orElseThrow(() -> new com.personal.marketnote.notification.domain.notification.NotificationNotFoundException(notification.getId()));
         entity.updateFrom(notification);
+    }
+
+    @Override
+    public void updateAll(List<Notification> notifications) {
+        List<Long> ids = notifications.stream().map(Notification::getId).toList();
+        Map<Long, NotificationJpaEntity> entityMap = notificationJpaRepository.findAllById(ids).stream()
+                .collect(Collectors.toMap(NotificationJpaEntity::getId, e -> e));
+        for (Notification notification : notifications) {
+            NotificationJpaEntity entity = entityMap.get(notification.getId());
+            if (FormatValidator.hasNoValue(entity)) {
+                continue;
+            }
+            entity.updateFrom(notification);
+        }
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
@@ -52,6 +52,16 @@ public class NotificationPreferencePersistenceAdapter implements SaveNotificatio
     }
 
     @Override
+    public List<NotificationPreference> findEnabledByUserIdsAndNotificationType(List<Long> userIds, NotificationType notificationType) {
+        return notificationPreferenceJpaRepository
+                .findByUserIdInAndNotificationTypeAndStatusAndEnabledTrue(userIds, notificationType, EntityStatus.ACTIVE)
+                .stream()
+                .map(NotificationPreferenceJpaEntityToDomainMapper::mapToDomain)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    @Override
     public void update(NotificationPreference preference) {
         notificationPreferenceJpaRepository.findById(preference.getId())
                 .ifPresent(entity -> entity.updateFrom(preference));

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
@@ -12,4 +12,7 @@ public interface NotificationPreferenceJpaRepository extends JpaRepository<Notif
     List<NotificationPreferenceJpaEntity> findAllByUserIdAndStatus(Long userId, EntityStatus status);
 
     Optional<NotificationPreferenceJpaEntity> findByUserIdAndNotificationTypeAndStatus(Long userId, NotificationType notificationType, EntityStatus status);
+
+    List<NotificationPreferenceJpaEntity> findByUserIdInAndNotificationTypeAndStatusAndEnabledTrue(
+            List<Long> userIds, NotificationType notificationType, EntityStatus status);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/SendBatchNotificationCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/SendBatchNotificationCommand.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.notification.port.in.command;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public record SendBatchNotificationCommand(
+        List<Long> userIds,
+        String templateCode,
+        Map<String, String> variables,
+        String deliveryChannel,
+        LocalDateTime scheduledAt
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/SendBatchNotificationResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/SendBatchNotificationResult.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+public record SendBatchNotificationResult(
+        int totalUserCount,
+        int sentUserCount,
+        int skippedUserCount,
+        int failedUserCount,
+        int totalDeviceSentCount,
+        int totalDeviceFailedCount
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/SendBatchNotificationUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/SendBatchNotificationUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+import com.personal.marketnote.notification.port.in.command.SendBatchNotificationCommand;
+import com.personal.marketnote.notification.port.in.result.notification.SendBatchNotificationResult;
+
+public interface SendBatchNotificationUseCase {
+
+    SendBatchNotificationResult sendBatchNotification(SendBatchNotificationCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/device/FindDeviceTokenPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/device/FindDeviceTokenPort.java
@@ -9,4 +9,6 @@ public interface FindDeviceTokenPort {
     Optional<DeviceToken> findActiveByDeviceId(String deviceId);
 
     List<DeviceToken> findActiveByUserId(Long userId);
+
+    List<DeviceToken> findActiveByUserIds(List<Long> userIds);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SaveNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SaveNotificationPort.java
@@ -2,6 +2,10 @@ package com.personal.marketnote.notification.port.out.notification;
 
 import com.personal.marketnote.notification.domain.notification.Notification;
 
+import java.util.List;
+
 public interface SaveNotificationPort {
     Notification save(Notification notification);
+
+    List<Notification> saveAll(List<Notification> notifications);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SendPushNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SendPushNotificationPort.java
@@ -1,9 +1,14 @@
 package com.personal.marketnote.notification.port.out.notification;
 
 import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.result.SendBatchPushNotificationResult;
 import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+
+import java.util.List;
 
 public interface SendPushNotificationPort {
 
     SendPushNotificationResult send(SendPushNotificationCommand command);
+
+    SendBatchPushNotificationResult sendBatch(List<SendPushNotificationCommand> commands);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/UpdateNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/UpdateNotificationPort.java
@@ -2,6 +2,10 @@ package com.personal.marketnote.notification.port.out.notification;
 
 import com.personal.marketnote.notification.domain.notification.Notification;
 
+import java.util.List;
+
 public interface UpdateNotificationPort {
     void update(Notification notification);
+
+    void updateAll(List<Notification> notifications);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/FindNotificationPreferencePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/FindNotificationPreferencePort.java
@@ -10,4 +10,6 @@ public interface FindNotificationPreferencePort {
     List<NotificationPreference> findAllByUserId(Long userId);
 
     Optional<NotificationPreference> findByUserIdAndNotificationType(Long userId, NotificationType notificationType);
+
+    List<NotificationPreference> findEnabledByUserIdsAndNotificationType(List<Long> userIds, NotificationType notificationType);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/result/SendBatchPushNotificationResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/result/SendBatchPushNotificationResult.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.notification.port.out.result;
+
+import java.util.List;
+
+public record SendBatchPushNotificationResult(
+        int successCount,
+        int failureCount,
+        List<FailedToken> failedTokens
+) {
+    public record FailedToken(
+            String deviceToken,
+            String errorCode,
+            boolean tokenInvalid
+    ) {
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendBatchNotificationService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendBatchNotificationService.java
@@ -1,0 +1,276 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.device.DeviceToken;
+import com.personal.marketnote.notification.domain.notification.*;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.domain.template.TemplateRenderer;
+import com.personal.marketnote.notification.port.in.command.SendBatchNotificationCommand;
+import com.personal.marketnote.notification.port.in.result.notification.SendBatchNotificationResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendBatchNotificationUseCase;
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.notification.SaveNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
+import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
+import com.personal.marketnote.notification.port.out.result.SendBatchPushNotificationResult;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.domain.notification.InvalidNotificationException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SendBatchNotificationService implements SendBatchNotificationUseCase {
+
+    private static final int MAX_BATCH_SIZE = 10_000;
+
+    private final FindNotificationTemplatePort findNotificationTemplatePort;
+    private final FindNotificationPreferencePort findNotificationPreferencePort;
+    private final FindDeviceTokenPort findDeviceTokenPort;
+    private final SaveNotificationPort saveNotificationPort;
+    private final UpdateNotificationPort updateNotificationPort;
+    private final SendPushNotificationPort sendPushNotificationPort;
+    private final DeleteDeviceTokenPort deleteDeviceTokenPort;
+    private final Clock clock;
+
+    @Override
+    public SendBatchNotificationResult sendBatchNotification(SendBatchNotificationCommand command) {
+        NotificationTemplate template = findTemplate(command.templateCode());
+        NotificationCategory category = template.getNotificationCategory();
+        List<Long> userIds = command.userIds().stream().distinct().toList();
+
+        if (userIds.isEmpty()) {
+            return emptyResult();
+        }
+
+        if (userIds.size() > MAX_BATCH_SIZE) {
+            throw new InvalidNotificationException(
+                    "대량 발송 대상은 최대 " + MAX_BATCH_SIZE + "명까지 가능합니다.");
+        }
+
+        Set<Long> consentedUserIds = resolveConsentedUserIds(category, userIds, template);
+        Set<Long> skippedUserIds = userIds.stream()
+                .filter(id -> !consentedUserIds.contains(id))
+                .collect(Collectors.toSet());
+
+        String title = TemplateRenderer.render(template.getTitle(), command.variables());
+        String body = TemplateRenderer.render(template.getBodyTemplate(), command.variables());
+        String landingUrl = TemplateRenderer.render(template.getUrlTemplate(), command.variables());
+
+        if (PromotionalNotificationPolicy.shouldApplyPolicy(category)) {
+            title = PromotionalNotificationPolicy.applyAdLabel(title);
+            body = PromotionalNotificationPolicy.applyOptOutGuide(body);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime scheduledAt = NightTimeNotificationPolicy.resolveScheduledAt(
+                category, now, command.scheduledAt());
+
+        DeliveryChannel deliveryChannel = DeliveryChannel.valueOf(command.deliveryChannel());
+
+        List<Notification> consentedNotifications = createNotifications(
+                new ArrayList<>(consentedUserIds), template, title, body, landingUrl,
+                deliveryChannel, scheduledAt);
+        List<Notification> skippedNotifications = createSkippedNotifications(
+                new ArrayList<>(skippedUserIds), template, deliveryChannel);
+
+        List<Notification> allToSave = new ArrayList<>();
+        allToSave.addAll(consentedNotifications);
+        allToSave.addAll(skippedNotifications);
+
+        List<Notification> savedNotifications = saveNotificationPort.saveAll(allToSave);
+
+        List<Notification> savedConsented = savedNotifications.stream()
+                .filter(n -> !n.getSendStatus().isSkipped())
+                .toList();
+        List<Notification> pendingNotifications = savedConsented.stream()
+                .filter(n -> n.getSendStatus().isPending())
+                .toList();
+
+        if (pendingNotifications.isEmpty() || !deliveryChannel.hasPush()) {
+            return buildResult(userIds.size(), 0, skippedUserIds.size(),
+                    0, 0, 0);
+        }
+
+        return sendPushAndProcessResults(
+                pendingNotifications, title, body, landingUrl,
+                userIds.size(), skippedUserIds.size());
+    }
+
+    private NotificationTemplate findTemplate(String templateCode) {
+        return findNotificationTemplatePort.findActiveByTemplateCode(templateCode)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(templateCode));
+    }
+
+    private Set<Long> resolveConsentedUserIds(NotificationCategory category,
+                                               List<Long> userIds,
+                                               NotificationTemplate template) {
+        if (!category.requiresConsent()) {
+            return new HashSet<>(userIds);
+        }
+        List<NotificationPreference> enabledPrefs =
+                findNotificationPreferencePort.findEnabledByUserIdsAndNotificationType(
+                        userIds, template.getNotificationType());
+        return enabledPrefs.stream()
+                .map(NotificationPreference::getUserId)
+                .collect(Collectors.toSet());
+    }
+
+    private List<Notification> createNotifications(List<Long> userIds,
+                                                    NotificationTemplate template,
+                                                    String title, String body, String landingUrl,
+                                                    DeliveryChannel deliveryChannel,
+                                                    LocalDateTime scheduledAt) {
+        return userIds.stream()
+                .map(userId -> {
+                    NotificationCreateState state = NotificationCreateState.builder()
+                            .userId(userId)
+                            .notificationType(template.getNotificationType())
+                            .title(title)
+                            .body(body)
+                            .deliveryChannel(deliveryChannel)
+                            .landingUrl(landingUrl)
+                            .scheduledAt(scheduledAt)
+                            .build();
+                    return Notification.from(state);
+                })
+                .toList();
+    }
+
+    private List<Notification> createSkippedNotifications(List<Long> userIds,
+                                                            NotificationTemplate template,
+                                                            DeliveryChannel deliveryChannel) {
+        return userIds.stream()
+                .map(userId -> {
+                    NotificationCreateState state = NotificationCreateState.builder()
+                            .userId(userId)
+                            .notificationType(template.getNotificationType())
+                            .title(template.getTitle())
+                            .body(template.getBodyTemplate())
+                            .deliveryChannel(deliveryChannel)
+                            .build();
+                    Notification notification = Notification.from(state);
+                    notification.markAsSkipped();
+                    return notification;
+                })
+                .toList();
+    }
+
+    private SendBatchNotificationResult sendPushAndProcessResults(
+            List<Notification> pendingNotifications,
+            String title, String body, String landingUrl,
+            int totalUserCount, int skippedCount) {
+
+        Map<Long, Notification> userIdToNotification = pendingNotifications.stream()
+                .collect(Collectors.toMap(Notification::getUserId, n -> n));
+
+        List<Long> pendingUserIds = new ArrayList<>(userIdToNotification.keySet());
+        List<DeviceToken> deviceTokens = findDeviceTokenPort.findActiveByUserIds(pendingUserIds);
+
+        Map<Long, List<DeviceToken>> tokensByUserId = deviceTokens.stream()
+                .collect(Collectors.groupingBy(DeviceToken::getUserId));
+
+        Set<Long> usersWithoutTokens = pendingUserIds.stream()
+                .filter(userId -> !tokensByUserId.containsKey(userId))
+                .collect(Collectors.toSet());
+
+        for (Long userId : usersWithoutTokens) {
+            Notification notification = userIdToNotification.get(userId);
+            notification.markAsFailed();
+        }
+
+        List<SendPushNotificationCommand> pushCommands = new ArrayList<>();
+        Map<String, DeviceToken> tokenMap = new HashMap<>();
+
+        for (Map.Entry<Long, List<DeviceToken>> entry : tokensByUserId.entrySet()) {
+            for (DeviceToken deviceToken : entry.getValue()) {
+                SendPushNotificationCommand pushCommand = new SendPushNotificationCommand(
+                        deviceToken.getToken(), title, body, landingUrl, deviceToken.getPlatform());
+                pushCommands.add(pushCommand);
+                tokenMap.put(deviceToken.getToken(), deviceToken);
+            }
+        }
+
+        int sentDeviceCount = 0;
+        int failedDeviceCount = 0;
+
+        if (!pushCommands.isEmpty()) {
+            SendBatchPushNotificationResult batchResult = sendPushNotificationPort.sendBatch(pushCommands);
+            sentDeviceCount = batchResult.successCount();
+            failedDeviceCount = batchResult.failureCount();
+
+            Set<Long> failedTokenIds = processFailedTokens(batchResult.failedTokens(), tokenMap);
+
+            Map<Long, Boolean> userSendSuccess = new HashMap<>();
+            for (Map.Entry<Long, List<DeviceToken>> entry : tokensByUserId.entrySet()) {
+                Long userId = entry.getKey();
+                boolean anySuccess = entry.getValue().stream()
+                        .anyMatch(dt -> !failedTokenIds.contains(dt.getId()));
+                userSendSuccess.put(userId, anySuccess);
+            }
+
+            for (Map.Entry<Long, Boolean> entry : userSendSuccess.entrySet()) {
+                Notification notification = userIdToNotification.get(entry.getKey());
+                if (entry.getValue()) {
+                    notification.markAsSent();
+                    continue;
+                }
+                notification.markAsFailed();
+            }
+        }
+
+        updateNotificationPort.updateAll(new ArrayList<>(userIdToNotification.values()));
+
+        int sentUserCount = (int) userIdToNotification.values().stream()
+                .filter(n -> n.getSendStatus().isSent())
+                .count();
+        int failedUserCount = (int) userIdToNotification.values().stream()
+                .filter(n -> n.getSendStatus().isFailed())
+                .count();
+
+        return buildResult(totalUserCount, sentUserCount, skippedCount,
+                failedUserCount, sentDeviceCount, failedDeviceCount);
+    }
+
+    private Set<Long> processFailedTokens(List<SendBatchPushNotificationResult.FailedToken> failedTokens,
+                                            Map<String, DeviceToken> tokenMap) {
+        Set<Long> failedTokenIds = new HashSet<>();
+        for (SendBatchPushNotificationResult.FailedToken failed : failedTokens) {
+            DeviceToken deviceToken = tokenMap.get(failed.deviceToken());
+            if (FormatValidator.hasNoValue(deviceToken)) {
+                continue;
+            }
+            failedTokenIds.add(deviceToken.getId());
+            if (failed.tokenInvalid()) {
+                deleteDeviceTokenPort.deleteById(deviceToken.getId());
+            }
+        }
+        return failedTokenIds;
+    }
+
+    private SendBatchNotificationResult buildResult(int totalUserCount, int sentUserCount,
+                                                      int skippedCount, int failedUserCount,
+                                                      int sentDeviceCount, int failedDeviceCount) {
+        return new SendBatchNotificationResult(
+                totalUserCount, sentUserCount, skippedCount,
+                failedUserCount, sentDeviceCount, failedDeviceCount);
+    }
+
+    private SendBatchNotificationResult emptyResult() {
+        return new SendBatchNotificationResult(0, 0, 0, 0, 0, 0);
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2106

## Task
- [x] SendBatchNotificationUseCase + SendBatchNotificationCommand + SendBatchNotificationResult 정의
- [x] SendBatchNotificationService 구현 (트랜잭션 분리 설계)
- [x] 대상 userId 목록으로 유효 토큰 일괄 조회 (FindDeviceTokenPort.findActiveByUserIds)
- [x] 수신 설정 일괄 필터링 (FindNotificationPreferencePort.findEnabledByUserIdsAndNotificationType)
- [x] 500건 단위 청크 분할 + FirebaseMessaging.sendEach() 발송
- [x] BatchResponse 개별 결과 처리 (성공/실패 분리)
- [x] 실패 토큰 deactivate + 이력 저장
- [x] 429 QUOTA_EXCEEDED 시 exponential backoff 재시도 (최대 3회)
- [x] 대량 발송 대상 최대 10,000명 제한
- [x] 중복 userId 자동 제거
- [x] updateAll N+1 쿼리 제거 (일괄 조회 방식)
- [x] InterruptedException 후 재시도 즉시 중단 처리
