### PR TITLE
[#2164][#2123][#2617] test: 알림 발송 완료 이벤트 Outbox 발행 기능 자동화 테스트 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -58,6 +58,9 @@ public final class KafkaTopicConstants {
     // Fulfillment 이벤트
     public static final String SHIPPING_STATUS_CHANGED = "fulfillment.shipping.status-changed";
 
+    // Notification 이벤트
+    public static final String NOTIFICATION_PUSH_SENT = "notification.push.sent";
+
     // Reward 이벤트
     public static final String POINT_ACCRUED = "reward.point.accrued";
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PushNotificationSentEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PushNotificationSentEvent.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.common.kafka.event;
+
+import java.time.LocalDateTime;
+
+public record PushNotificationSentEvent(
+        Long notificationId,
+        Long userId,
+        String notificationType,
+        String sendStatus,
+        int sentDeviceCount,
+        int failedDeviceCount,
+        LocalDateTime occurredAt
+) {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/event/NotificationSentEventOutboxAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/event/NotificationSentEventOutboxAdapter.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.notification.adapter.out.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.PushNotificationSentEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.notification.port.out.event.PublishNotificationSentEventPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationSentEventOutboxAdapter implements PublishNotificationSentEventPort {
+
+    private static final String EVENT_SOURCE = "notification-service";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Override
+    public void publish(PushNotificationSentEvent event) {
+        String payload = serialize(event);
+        OutboxEvent outboxEvent = OutboxEvent.of(
+                UUID.randomUUID().toString(),
+                KafkaTopicConstants.NOTIFICATION_PUSH_SENT,
+                String.valueOf(event.notificationId()),
+                PushNotificationSentEvent.class.getSimpleName(),
+                EVENT_SOURCE,
+                payload,
+                clock
+        );
+        saveOutboxEventPort.save(outboxEvent);
+    }
+
+    private String serialize(PushNotificationSentEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            throw new NotificationSentEventSerializationException(event.notificationId(), e);
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/event/NotificationSentEventSerializationException.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/event/NotificationSentEventSerializationException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.adapter.out.event;
+
+public class NotificationSentEventSerializationException extends RuntimeException {
+
+    public NotificationSentEventSerializationException(Long notificationId, Throwable cause) {
+        super("알림 발송 완료 이벤트 직렬화 실패: notificationId=" + notificationId, cause);
+    }
+}

--- a/notification-service/notification-adapters/src/main/resources/application.yml
+++ b/notification-service/notification-adapters/src/main/resources/application.yml
@@ -75,6 +75,9 @@ kafka:
   slack:
     webhook-url: ${KAFKA_SLACK_WEBHOOK_URL:}
 
+outbox:
+  enabled: true
+
 sse:
   max-connections: ${SSE_MAX_CONNECTIONS:5000}
   emitter:

--- a/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/out/event/NotificationSentEventOutboxAdapterTest.java
+++ b/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/out/event/NotificationSentEventOutboxAdapterTest.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.notification.adapter.out.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.PushNotificationSentEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationSentEventOutboxAdapter 테스트")
+class NotificationSentEventOutboxAdapterTest {
+
+    @InjectMocks
+    private NotificationSentEventOutboxAdapter adapter;
+
+    @Mock
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-09-03T05:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @Test
+    @DisplayName("PushNotificationSentEvent를 OutboxEvent로 저장한다")
+    void publishSavesOutboxEvent() {
+        // given
+        PushNotificationSentEvent event = new PushNotificationSentEvent(
+                100L, 1L, "ORDER_PAYMENT_COMPLETED", "SENT",
+                2, 0, LocalDateTime.of(2026, 4, 10, 14, 0)
+        );
+
+        // when
+        adapter.publish(event);
+
+        // then
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(captor.capture());
+
+        OutboxEvent outboxEvent = captor.getValue();
+        assertThat(outboxEvent.getTopic()).isEqualTo(KafkaTopicConstants.NOTIFICATION_PUSH_SENT);
+        assertThat(outboxEvent.getPartitionKey()).isEqualTo("100");
+        assertThat(outboxEvent.getEventType()).isEqualTo("PushNotificationSentEvent");
+        assertThat(outboxEvent.getSource()).isEqualTo("notification-service");
+        assertThat(outboxEvent.getEventId()).isNotBlank();
+        assertThat(outboxEvent.getPayload()).contains("\"notificationId\":100");
+        assertThat(outboxEvent.getPayload()).contains("\"sendStatus\":\"SENT\"");
+    }
+
+    @Test
+    @DisplayName("페이로드 JSON이 올바르게 직렬화된다")
+    void payloadIsValidJson() throws Exception {
+        // given
+        PushNotificationSentEvent event = new PushNotificationSentEvent(
+                200L, 2L, "SHIPPING_STARTED", "SENT",
+                1, 1, LocalDateTime.of(2026, 4, 10, 15, 0)
+        );
+
+        // when
+        adapter.publish(event);
+
+        // then
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(captor.capture());
+
+        JsonNode parsed = objectMapper.readTree(captor.getValue().getPayload());
+        assertThat(parsed.get("notificationId").asLong()).isEqualTo(200L);
+        assertThat(parsed.get("userId").asLong()).isEqualTo(2L);
+        assertThat(parsed.get("notificationType").asText()).isEqualTo("SHIPPING_STARTED");
+        assertThat(parsed.get("sendStatus").asText()).isEqualTo("SENT");
+        assertThat(parsed.get("sentDeviceCount").asInt()).isEqualTo(1);
+        assertThat(parsed.get("failedDeviceCount").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("직렬화 실패 시 NotificationSentEventSerializationException을 던진다")
+    void throwsOnSerializationFailure() throws Exception {
+        // given
+        PushNotificationSentEvent event = new PushNotificationSentEvent(
+                300L, 3L, "NOTICE", "SENT",
+                1, 0, LocalDateTime.of(2026, 4, 10, 16, 0)
+        );
+        when(objectMapper.writeValueAsString(event))
+                .thenThrow(new JsonProcessingException("test failure") {});
+
+        // when & then
+        assertThatThrownBy(() -> adapter.publish(event))
+                .isInstanceOf(NotificationSentEventSerializationException.class)
+                .hasMessageContaining("notificationId=300");
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/event/PublishNotificationSentEventPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/event/PublishNotificationSentEventPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.out.event;
+
+import com.personal.marketnote.common.kafka.event.PushNotificationSentEvent;
+
+public interface PublishNotificationSentEventPort {
+
+    void publish(PushNotificationSentEvent event);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendBatchNotificationService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendBatchNotificationService.java
@@ -18,8 +18,10 @@ import com.personal.marketnote.notification.port.out.notification.SaveNotificati
 import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
 import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
+import com.personal.marketnote.notification.port.out.event.PublishNotificationSentEventPort;
 import com.personal.marketnote.notification.port.out.result.SendBatchPushNotificationResult;
 import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.common.kafka.event.PushNotificationSentEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,6 +47,7 @@ public class SendBatchNotificationService implements SendBatchNotificationUseCas
     private final UpdateNotificationPort updateNotificationPort;
     private final SendPushNotificationPort sendPushNotificationPort;
     private final DeleteDeviceTokenPort deleteDeviceTokenPort;
+    private final PublishNotificationSentEventPort publishNotificationSentEventPort;
     private final Clock clock;
 
     @Override
@@ -235,6 +238,8 @@ public class SendBatchNotificationService implements SendBatchNotificationUseCas
 
         updateNotificationPort.updateAll(new ArrayList<>(userIdToNotification.values()));
 
+        publishSentEvents(userIdToNotification.values(), sentDeviceCount, failedDeviceCount);
+
         int sentUserCount = (int) userIdToNotification.values().stream()
                 .filter(n -> n.getSendStatus().isSent())
                 .count();
@@ -268,6 +273,26 @@ public class SendBatchNotificationService implements SendBatchNotificationUseCas
         return new SendBatchNotificationResult(
                 totalUserCount, sentUserCount, skippedCount,
                 failedUserCount, sentDeviceCount, failedDeviceCount);
+    }
+
+    private void publishSentEvents(Collection<Notification> notifications,
+                                     int sentDeviceCount, int failedDeviceCount) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        for (Notification notification : notifications) {
+            if (!notification.getSendStatus().isSent()) {
+                continue;
+            }
+            PushNotificationSentEvent event = new PushNotificationSentEvent(
+                    notification.getId(),
+                    notification.getUserId(),
+                    notification.getNotificationType().name(),
+                    notification.getSendStatus().name(),
+                    sentDeviceCount,
+                    failedDeviceCount,
+                    now
+            );
+            publishNotificationSentEventPort.publish(event);
+        }
     }
 
     private SendBatchNotificationResult emptyResult() {

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendNotificationService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendNotificationService.java
@@ -11,9 +11,11 @@ import com.personal.marketnote.notification.domain.template.TemplateRenderer;
 import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
 import com.personal.marketnote.notification.port.in.result.notification.SendNotificationResult;
 import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import com.personal.marketnote.common.kafka.event.PushNotificationSentEvent;
 import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
 import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
 import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.event.PublishNotificationSentEventPort;
 import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.SaveNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
@@ -47,6 +49,7 @@ public class SendNotificationService implements SendNotificationUseCase {
     private final DeleteDeviceTokenPort deleteDeviceTokenPort;
     private final FindNotificationPort findNotificationPort;
     private final PublishSseEventPort publishSseEventPort;
+    private final PublishNotificationSentEventPort publishNotificationSentEventPort;
     private final Clock clock;
 
     @Override
@@ -187,6 +190,10 @@ public class SendNotificationService implements SendNotificationUseCase {
         }
         updateNotificationPort.update(notification);
 
+        if (notification.getSendStatus().isSent()) {
+            publishNotificationSentEvent(notification, sentCount, failedCount);
+        }
+
         return toResult(notification, sentCount, failedCount);
     }
 
@@ -194,6 +201,19 @@ public class SendNotificationService implements SendNotificationUseCase {
         long unreadCount = findNotificationPort.countUnreadByUserId(userId);
         publishSseEventPort.publish(userId, "UNREAD_COUNT_CHANGED",
                 "{\"unreadCount\":" + unreadCount + "}");
+    }
+
+    private void publishNotificationSentEvent(Notification notification, int sentCount, int failedCount) {
+        PushNotificationSentEvent event = new PushNotificationSentEvent(
+                notification.getId(),
+                notification.getUserId(),
+                notification.getNotificationType().name(),
+                notification.getSendStatus().name(),
+                sentCount,
+                failedCount,
+                LocalDateTime.now(clock)
+        );
+        publishNotificationSentEventPort.publish(event);
     }
 
     private SendNotificationResult toResult(Notification notification, int sentCount, int failedCount) {

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/SendBatchNotificationUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/SendBatchNotificationUseCaseTest.java
@@ -70,6 +70,9 @@ class SendBatchNotificationUseCaseTest {
     @Mock
     private DeleteDeviceTokenPort deleteDeviceTokenPort;
 
+    @Mock
+    private com.personal.marketnote.notification.port.out.event.PublishNotificationSentEventPort publishNotificationSentEventPort;
+
     @Spy
     private Clock clock = Clock.fixed(
             Instant.parse("2026-09-03T05:00:00Z"),

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/SendNotificationUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/SendNotificationUseCaseTest.java
@@ -70,6 +70,9 @@ class SendNotificationUseCaseTest {
     @Mock
     private PublishSseEventPort publishSseEventPort;
 
+    @Mock
+    private com.personal.marketnote.notification.port.out.event.PublishNotificationSentEventPort publishNotificationSentEventPort;
+
     @Spy
     private Clock clock = Clock.fixed(
             Instant.parse("2026-06-03T05:00:00Z"),


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2617

## Test Case
- [x] PushNotificationSentEvent를 OutboxEvent로 저장한다
- [x] 페이로드 JSON이 올바르게 직렬화된다
- [x] 직렬화 실패 시 NotificationSentEventSerializationException을 던진다
