### PR TITLE
[#2164][#2123][#2584] test: 구매 확정 완료 시 푸시 알림 발송 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationCompletedPushNotificationConsumerTest.java
+++ b/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationCompletedPushNotificationConsumerTest.java
@@ -1,0 +1,142 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseConfirmationCompletedPushNotificationConsumerTest {
+
+    @InjectMocks
+    private PurchaseConfirmationCompletedPushNotificationConsumer consumer;
+
+    @Mock
+    private SendNotificationUseCase sendNotificationUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId) {
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(
+                orderId, buyerId, List.of(UUID.randomUUID())
+        );
+        EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.order.purchase-confirmed", "commerce-service",
+                LocalDateTime.of(2026, 4, 10, 15, 0), event
+        );
+        return new ConsumerRecord<>("commerce.order.purchase-confirmed", 0, 0L,
+                String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("구매 확정 이벤트 수신 시 푸시 알림을 발송하고 acknowledge한다")
+    void shouldSendPushNotificationAndAcknowledge() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, 1L);
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<SendNotificationCommand> captor = ArgumentCaptor.forClass(SendNotificationCommand.class);
+        verify(sendNotificationUseCase).sendNotification(captor.capture());
+
+        SendNotificationCommand command = captor.getValue();
+        assertThat(command.userId()).isEqualTo(1L);
+        assertThat(command.templateCode()).isEqualTo("PURCHASE_CONFIRMATION_COMPLETED");
+        assertThat(command.deliveryChannel()).isEqualTo("PUSH_ONLY");
+        assertThat(command.variables()).containsEntry("order_id", "100");
+        assertThat(command.scheduledAt()).isNull();
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenEnvelopeIsNull() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.purchase-confirmed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenEventTypeMismatch() {
+        // given
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(
+                100L, 1L, List.of()
+        );
+        EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 4, 10, 15, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.purchase-confirmed", 0, 0L, "100", envelope
+        );
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenBuyerIdIsNull() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(100L, null);
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 알림을 발송하지 않고 acknowledge한다")
+    void shouldSkipWhenOrderIdIsNull() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 1L);
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(sendNotificationUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2584

## Test Case
- [x] 구매 확정 이벤트 수신 시 푸시 알림을 발송하고 acknowledge한다
- [x] envelope이 null이면 알림을 발송하지 않고 acknowledge한다
- [x] eventType이 불일치하면 알림을 발송하지 않고 acknowledge한다
- [x] buyerId가 null이면 알림을 발송하지 않고 acknowledge한다
- [x] orderId가 null이면 알림을 발송하지 않고 acknowledge한다
