### PR TITLE
[#929][#2696] feat: 반품 신청 시 Kafka 이벤트(ReturnRequestedEvent) Outbox 발행 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -126,6 +126,17 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
     }
 
     @Override
+    public void publishReturnRequestedEvent(Long orderId, Long buyerId) {
+        ReturnRequestedEvent payload = new ReturnRequestedEvent(orderId, buyerId);
+        String topic = KafkaTopicConstants.RETURN_REQUESTED;
+        EventEnvelope<ReturnRequestedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        saveToOutbox(envelope, topic, orderId.toString());
+    }
+
+    @Override
     public void publishOrderCancelFailedEvent(Long orderId, Long buyerId) {
         OrderCancelFailedEvent payload = new OrderCancelFailedEvent(orderId, buyerId);
         String topic = KafkaTopicConstants.ORDER_CANCEL_FAILED;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -24,4 +24,6 @@ public interface PublishOrderEventPort {
                                    Long returnShippingFee, List<OrderProduct> returnProducts);
 
     void publishOrderCancelFailedEvent(Long orderId, Long buyerId);
+
+    void publishReturnRequestedEvent(Long orderId, Long buyerId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessExcepti
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.RequestReturnUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.service.returntracker.CreateReturnTrackerAfterReturnRequestService;
@@ -33,6 +34,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RequestReturnService implements RequestReturnUseCase {
     private final GetOrderUseCase getOrderUseCase;
     private final UpdateOrderPort updateOrderPort;
+    private final PublishOrderEventPort publishOrderEventPort;
     private final CreateReturnTrackerAfterReturnRequestService createReturnTrackerAfterReturnRequestService;
     private final Clock clock;
 
@@ -62,6 +64,7 @@ public class RequestReturnService implements RequestReturnUseCase {
         );
 
         updateOrderPort.update(order, orderStatusHistory);
+        publishOrderEventPort.publishReturnRequestedEvent(order.getId(), order.getBuyerId());
 
         RegisterFulfillmentReturnDeliveryCommand returnDeliveryCommand = buildReturnDeliveryCommand(command, order);
         runAfterCommit(() -> createReturnTrackerAfterReturnRequestService.createReturnTracker(returnDeliveryCommand));

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedExcep
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.service.returntracker.CreateReturnTrackerAfterReturnRequestService;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,8 @@ class RequestReturnUseCaseTest {
     private GetOrderUseCase getOrderUseCase;
     @Mock
     private UpdateOrderPort updateOrderPort;
+    @Mock
+    private PublishOrderEventPort publishOrderEventPort;
     @Mock
     private CreateReturnTrackerAfterReturnRequestService createReturnTrackerAfterReturnRequestService;
     @Spy

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -15,6 +15,7 @@ public final class KafkaTopicConstants {
     public static final String ORDER_CANCEL_FAILED = "commerce.order.cancel-failed";
     public static final String ORDER_PURCHASE_CONFIRMED = "commerce.order.purchase-confirmed";
     public static final String ORDER_RETURNED = "commerce.order.returned";
+    public static final String RETURN_REQUESTED = "commerce.order.return-requested";
     public static final String RETURN_INSPECTION_COMPLETED = "commerce.return-inspection.completed";
 
     // Product 이벤트

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ReturnRequestedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ReturnRequestedEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record ReturnRequestedEvent(
+        Long orderId,
+        Long buyerId
+) {
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #2696

## Task
- [x] ReturnRequestedEvent(orderId, buyerId) 이벤트 클래스 생성 (common 모듈)
- [x] KafkaTopicConstants.RETURN_REQUESTED 토픽 상수 추가
- [x] PublishOrderEventPort에 publishReturnRequestedEvent 메서드 추가
- [x] OrderEventKafkaProducer에 Outbox 발행 구현
- [x] RequestReturnService에 이벤트 발행 호출 추가
- [x] RequestReturnUseCaseTest에 PublishOrderEventPort mock 추가 (기존 테스트 깨짐 수정)
