### PR TITLE
[#2164][#2123][#2121] feat: 예약 발송 스케줄러 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/scheduler/ScheduledNotificationPublisher.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/scheduler/ScheduledNotificationPublisher.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.notification.adapter.in.scheduler;
+
+import com.personal.marketnote.notification.port.in.usecase.notification.PublishScheduledNotificationsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "notification.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ScheduledNotificationPublisher {
+
+    private final PublishScheduledNotificationsUseCase publishScheduledNotificationsUseCase;
+
+    @Scheduled(fixedDelayString = "${notification.scheduler.scheduled-publish-interval-ms:60000}")
+    public void publishScheduledNotifications() {
+        log.debug("예약 알림 발송 스케줄러 실행");
+        int processedCount = publishScheduledNotificationsUseCase.publishScheduledNotifications();
+        if (processedCount > 0) {
+            log.info("예약 알림 발송 스케줄러 완료: {}건 처리", processedCount);
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.notification.adapter.out.mapper.NotificationJpaEntityToDomainMapper;
 import com.personal.marketnote.notification.adapter.out.persistence.notification.repository.NotificationJpaRepository;
 import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
 import com.personal.marketnote.notification.adapter.out.persistence.notification.entity.NotificationJpaEntity;
 import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.SaveNotificationPort;
@@ -13,6 +14,7 @@ import com.personal.marketnote.notification.port.out.notification.UpdateNotifica
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +51,15 @@ public class NotificationPersistenceAdapter implements FindNotificationPort, Sav
     @Override
     public long countUnreadByUserId(Long userId) {
         return notificationJpaRepository.countByUserIdAndStatusAndIsRead(userId, EntityStatus.ACTIVE, false);
+    }
+
+    @Override
+    public List<Notification> findScheduledNotificationsDue(LocalDateTime now) {
+        return notificationJpaRepository.findScheduledNotificationsDue(
+                        SendStatus.SCHEDULED, now, EntityStatus.ACTIVE)
+                .stream()
+                .flatMap(entity -> NotificationJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
     }
 
     @Override

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,4 +34,17 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationJpa
     long countByUserIdAndStatus(Long userId, EntityStatus status);
 
     long countByUserIdAndStatusAndIsRead(Long userId, EntityStatus status, boolean isRead);
+
+    @Query("""
+            SELECT n FROM NotificationJpaEntity n
+            WHERE n.sendStatus = :sendStatus
+              AND n.scheduledAt <= :now
+              AND n.status = :status
+            ORDER BY n.scheduledAt ASC
+            """)
+    List<NotificationJpaEntity> findScheduledNotificationsDue(
+            @Param("sendStatus") SendStatus sendStatus,
+            @Param("now") LocalDateTime now,
+            @Param("status") EntityStatus status
+    );
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/SchedulingConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/SchedulingConfig.java
@@ -12,7 +12,7 @@ public class SchedulingConfig {
     @Bean
     public ThreadPoolTaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(1);
+        scheduler.setPoolSize(4);
         scheduler.setThreadNamePrefix("notification-scheduler-");
         scheduler.setWaitForTasksToCompleteOnShutdown(true);
         scheduler.setAwaitTerminationSeconds(30);

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/PublishScheduledNotificationsUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/PublishScheduledNotificationsUseCase.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+public interface PublishScheduledNotificationsUseCase {
+
+    int publishScheduledNotifications();
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.notification.port.out.notification;
 
 import com.personal.marketnote.notification.domain.notification.Notification;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +15,6 @@ public interface FindNotificationPort {
     long countByUserId(Long userId);
 
     long countUnreadByUserId(Long userId);
+
+    List<Notification> findScheduledNotificationsDue(LocalDateTime now);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/PublishScheduledNotificationsService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/PublishScheduledNotificationsService.java
@@ -1,0 +1,107 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.device.DeviceToken;
+import com.personal.marketnote.notification.domain.notification.FcmSendFailedException;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.port.in.usecase.notification.PublishScheduledNotificationsUseCase;
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class PublishScheduledNotificationsService implements PublishScheduledNotificationsUseCase {
+
+    private final FindNotificationPort findNotificationPort;
+    private final FindDeviceTokenPort findDeviceTokenPort;
+    private final SendPushNotificationPort sendPushNotificationPort;
+    private final UpdateNotificationPort updateNotificationPort;
+    private final DeleteDeviceTokenPort deleteDeviceTokenPort;
+    private final Clock clock;
+
+    @Override
+    public int publishScheduledNotifications() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<Notification> scheduledNotifications = findNotificationPort.findScheduledNotificationsDue(now);
+
+        if (scheduledNotifications.isEmpty()) {
+            return 0;
+        }
+
+        int processedCount = 0;
+        for (Notification notification : scheduledNotifications) {
+            try {
+                processScheduledNotification(notification);
+                processedCount++;
+            } catch (Exception e) {
+                log.error("예약 알림 처리 실패: notificationId={}", notification.getId(), e);
+            }
+        }
+
+        log.info("예약 알림 발송 완료: 총={}건, 처리={}건", scheduledNotifications.size(), processedCount);
+        return processedCount;
+    }
+
+    private void processScheduledNotification(Notification notification) {
+        notification.markAsPending();
+
+        if (!notification.getDeliveryChannel().hasPush()) {
+            updateNotificationPort.update(notification);
+            return;
+        }
+
+        sendPushForNotification(notification);
+        updateNotificationPort.update(notification);
+    }
+
+    private void sendPushForNotification(Notification notification) {
+        List<DeviceToken> deviceTokens = findDeviceTokenPort.findActiveByUserId(notification.getUserId());
+
+        if (deviceTokens.isEmpty()) {
+            notification.markAsFailed();
+            return;
+        }
+
+        int sentCount = 0;
+        int failedCount = 0;
+
+        for (DeviceToken deviceToken : deviceTokens) {
+            SendPushNotificationCommand pushCommand = new SendPushNotificationCommand(
+                    deviceToken.getToken(), notification.getTitle(), notification.getBody(),
+                    notification.getLandingUrl(), deviceToken.getPlatform());
+            try {
+                SendPushNotificationResult pushResult = sendPushNotificationPort.send(pushCommand);
+                if (pushResult.success()) {
+                    sentCount++;
+                    continue;
+                }
+                failedCount++;
+                if (pushResult.tokenInvalid()) {
+                    deleteDeviceTokenPort.deleteById(deviceToken.getId());
+                }
+            } catch (FcmSendFailedException fsfe) {
+                log.error("FCM 발송 중 예외 발생: notificationId={}, deviceId={}",
+                        notification.getId(), deviceToken.getDeviceId());
+                failedCount++;
+            }
+        }
+
+        if (sentCount > 0) {
+            notification.markAsSent();
+            return;
+        }
+        notification.markAsFailed();
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
@@ -89,6 +89,14 @@ public class Notification extends BaseDomain {
         this.sendStatus = SendStatus.SKIPPED;
     }
 
+    public void markAsPending() {
+        if (!this.sendStatus.isScheduled()) {
+            throw new InvalidNotificationException(
+                    "SCHEDULED 상태에서만 PENDING으로 전환할 수 있습니다. 현재 상태: " + this.sendStatus);
+        }
+        this.sendStatus = SendStatus.PENDING;
+    }
+
     private static void validate(NotificationCreateState state) {
         if (FormatValidator.hasNoValue(state.getUserId())) {
             throw new InvalidNotificationException("사용자 ID는 필수입니다.");


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2121

## Task
- [x] Notification.markAsPending() 상태 전이 메서드 추가 (SCHEDULED → PENDING precondition 검증)
- [x] FindNotificationPort.findScheduledNotificationsDue 메서드 추가
- [x] NotificationJpaRepository에 SCHEDULED + scheduledAt <= now 쿼리 추가
- [x] PublishScheduledNotificationsUseCase + PublishScheduledNotificationsService 구현
- [x] ScheduledNotificationPublisher 스케줄러 (fixedDelay 60초, @ConditionalOnProperty)
- [x] SchedulingConfig 스레드 풀 크기 1 → 4 조정
- [x] 개별 알림 처리 try-catch 격리 (하나 실패해도 나머지 계속 처리)
