### PR TITLE
[#2164][#2124][#2135][#2536] feat: 구매 확정 완료 인앱 알림 생성 기능 추가 / 사용자 수동 구매 확정 완료 시 인앱 알림 생성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -53,8 +53,8 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
     }
 
     @Override
-    public void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<UUID> sharerKeys) {
-        OrderPurchaseConfirmedEvent payload = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys);
+    public void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<UUID> sharerKeys, boolean isAutoConfirmed) {
+        OrderPurchaseConfirmedEvent payload = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys, isAutoConfirmed);
         String topic = KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED;
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = EventEnvelope.of(
                 topic, SOURCE, payload, clock

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -11,7 +11,7 @@ public interface PublishOrderEventPort {
                                            Long pointAmount, List<OrderProduct> orderProducts,
                                            Long totalAccumulatedPoint);
 
-    void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<UUID> sharerKeys);
+    void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<UUID> sharerKeys, boolean isAutoConfirmed);
 
     void publishOrderCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                     Long cancelAmount, Long paymentAmount, Long pointAmount,

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -168,7 +168,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
 
     private void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<UUID> sharerKeys) {
         try {
-            publishOrderEventPort.publishOrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys);
+            publishOrderEventPort.publishOrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys, true);
         } catch (Exception e) {
             log.error("구매 확정 이벤트 발행 실패 - orderId: {}, buyerId: {}, error: {}",
                     orderId, buyerId, e.getMessage(), e);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ConfirmOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ConfirmOrderService.java
@@ -81,7 +81,7 @@ public class ConfirmOrderService implements ConfirmOrderUseCase {
 
         try {
             publishOrderEventPort.publishOrderPurchaseConfirmedEvent(
-                    order.getId(), order.getBuyerId(), sharerKeys
+                    order.getId(), order.getBuyerId(), sharerKeys, false
             );
         } catch (Exception e) {
             log.error("구매 확정 이벤트 발행 실패 - orderId: {}, buyerId: {}, error: {}",

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ConfirmOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ConfirmOrderUseCaseTest.java
@@ -119,7 +119,7 @@ class ConfirmOrderUseCaseTest {
             confirmOrderService.confirmOrder(command);
 
             verify(publishOrderEventPort).publishOrderPurchaseConfirmedEvent(
-                    eq(orderId), eq(buyerId), anyList()
+                    eq(orderId), eq(buyerId), anyList(), eq(false)
             );
         }
     }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPurchaseConfirmedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPurchaseConfirmedEvent.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 public record OrderPurchaseConfirmedEvent(
         Long orderId,
         Long buyerId,
-        List<UUID> sharerKeys
+        List<UUID> sharerKeys,
+        boolean isAutoConfirmed
 ) {
 }

--- a/common/src/test/java/com/personal/marketnote/common/kafka/event/KafkaMessageSerializationSchemaCompatibilityTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/kafka/event/KafkaMessageSerializationSchemaCompatibilityTest.java
@@ -304,7 +304,7 @@ class KafkaMessageSerializationSchemaCompatibilityTest {
         @DisplayName("OrderPurchaseConfirmedEvent를 EventEnvelope에 담아 직렬화/역직렬화 라운드트립 시 모든 필드가 보존된다")
         void orderPurchaseConfirmedEvent_roundTrip_preservesAllFields() throws Exception {
             // given
-            OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 10L, List.of(SHARER_KEY_1, SHARER_KEY_2, SHARER_KEY_3));
+            OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 10L, List.of(SHARER_KEY_1, SHARER_KEY_2, SHARER_KEY_3), false);
             EventEnvelope<OrderPurchaseConfirmedEvent> envelope = EventEnvelope.of(
                     "commerce.order.purchase-confirmed", "commerce-service", event, FIXED_CLOCK);
 

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationCompletedInAppNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationCompletedInAppNotificationConsumer.java
@@ -1,0 +1,85 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PurchaseConfirmationCompletedInAppNotificationConsumer {
+
+    private static final String TEMPLATE_CODE_AUTO = "PURCHASE_CONFIRMATION_COMPLETED_AUTO";
+    private static final String TEMPLATE_CODE_MANUAL = "PURCHASE_CONFIRMATION_COMPLETED_MANUAL";
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED,
+            groupId = "notification-purchase-confirmation-inapp"
+    )
+    public void handleOrderPurchaseConfirmedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        OrderPurchaseConfirmedEvent payload = envelope.getPayloadAs(OrderPurchaseConfirmedEvent.class, objectMapper);
+
+        String templateCode = resolveTemplateCode(payload.isAutoConfirmed());
+
+        log.info("구매 확정 이벤트 수신 (인앱 알림 생성). eventId={}, orderId={}, buyerId={}, isAutoConfirmed={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId(), payload.isAutoConfirmed());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SendNotificationCommand command = new SendNotificationCommand(
+                payload.buyerId(),
+                templateCode,
+                Map.of("order_id", String.valueOf(payload.orderId())),
+                "IN_APP_ONLY",
+                null
+        );
+        sendNotificationUseCase.sendNotification(command);
+
+        log.info("구매 확정 완료 인앱 알림 생성 완료. orderId={}, buyerId={}, templateCode={}",
+                payload.orderId(), payload.buyerId(), templateCode);
+
+        acknowledgment.acknowledge();
+    }
+
+    private String resolveTemplateCode(boolean isAutoConfirmed) {
+        if (isAutoConfirmed) {
+            return TEMPLATE_CODE_AUTO;
+        }
+        return TEMPLATE_CODE_MANUAL;
+    }
+}

--- a/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationCompletedPushNotificationConsumerTest.java
+++ b/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/in/event/PurchaseConfirmationCompletedPushNotificationConsumerTest.java
@@ -40,7 +40,7 @@ class PurchaseConfirmationCompletedPushNotificationConsumerTest {
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId) {
         OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(
-                orderId, buyerId, List.of(UUID.randomUUID())
+                orderId, buyerId, List.of(UUID.randomUUID()), false
         );
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.purchase-confirmed", "commerce-service",
@@ -94,7 +94,7 @@ class PurchaseConfirmationCompletedPushNotificationConsumerTest {
     void shouldSkipWhenEventTypeMismatch() {
         // given
         OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(
-                100L, 1L, List.of()
+                100L, 1L, List.of(), false
         );
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "wrong.event.type", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumerTest.java
@@ -42,7 +42,7 @@ class OrderPurchaseConfirmedProductPointConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId, List<UUID> sharerKeys) {
-        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys);
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys, false);
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.purchase-confirmed", "commerce-service",
                 LocalDateTime.of(2026, 3, 8, 10, 0), event
@@ -104,7 +104,7 @@ class OrderPurchaseConfirmedProductPointConsumerTest {
     @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
     void handleOrderPurchaseConfirmedEvent_eventTypeMismatch_skipsAndAcknowledges() {
         // given
-        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 100L, List.<UUID>of());
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 100L, List.<UUID>of(), false);
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "wrong.event.type", "commerce-service",
                 LocalDateTime.of(2026, 3, 8, 10, 0), event

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumerTest.java
@@ -52,7 +52,7 @@ class OrderPurchaseConfirmedSharedPointConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId, List<UUID> sharerKeys) {
-        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys);
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys, false);
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.purchase-confirmed", "commerce-service",
                 LocalDateTime.of(2026, 3, 8, 10, 0), event
@@ -143,7 +143,7 @@ class OrderPurchaseConfirmedSharedPointConsumerTest {
     @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
     void handleOrderPurchaseConfirmedEvent_eventTypeMismatch_skipsAndAcknowledges() {
         // given
-        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 100L, List.of(SHARER_KEY_1, SHARER_KEY_2));
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 100L, List.of(SHARER_KEY_1, SHARER_KEY_2), false);
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "wrong.event.type", "commerce-service",
                 LocalDateTime.of(2026, 3, 8, 10, 0), event


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2135
## resolves #2536

## Task
- [x] OrderPurchaseConfirmedEvent에 isAutoConfirmed 필드 추가
- [x] PublishOrderEventPort.publishOrderPurchaseConfirmedEvent()에 isAutoConfirmed 파라미터 추가
- [x] ConfirmOrderService (수동): isAutoConfirmed=false 전달
- [x] ChangeOrderStatusService (자동 스케줄러 경유): isAutoConfirmed=true 전달
- [x] PurchaseConfirmationCompletedInAppNotificationConsumer 생성 (자동: PURCHASE_CONFIRMATION_COMPLETED_AUTO / 수동: PURCHASE_CONFIRMATION_COMPLETED_MANUAL)
- [x] 기존 테스트 시그니처 수정 (common, commerce, reward, notification)
