### PR TITLE
[#2164][#2123][#2107] feat: Stale 디바이스 토큰 정리 스케줄러 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/scheduler/StaleDeviceTokenCleanupScheduler.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/scheduler/StaleDeviceTokenCleanupScheduler.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.notification.adapter.in.scheduler;
+
+import com.personal.marketnote.notification.port.in.usecase.device.CleanupStaleDeviceTokensUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "notification.cleanup", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class StaleDeviceTokenCleanupScheduler {
+
+    private final CleanupStaleDeviceTokensUseCase cleanupStaleDeviceTokensUseCase;
+
+    @Scheduled(cron = "${notification.cleanup.stale-token-cron:0 0 4 * * *}")
+    public void cleanupStaleDeviceTokens() {
+        log.debug("Stale 디바이스 토큰 정리 스케줄러 실행");
+        int deactivatedCount = cleanupStaleDeviceTokensUseCase.cleanupStaleDeviceTokens();
+        if (deactivatedCount > 0) {
+            log.info("Stale 디바이스 토큰 정리 스케줄러 완료: {}건 비활성화", deactivatedCount);
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/DeviceTokenPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/DeviceTokenPersistenceAdapter.java
@@ -13,6 +13,8 @@ import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
 import com.personal.marketnote.notification.port.out.device.SaveDeviceTokenPort;
 import com.personal.marketnote.notification.port.out.device.UpdateDeviceTokenPort;
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
@@ -62,6 +64,12 @@ public class DeviceTokenPersistenceAdapter
                 .orElseThrow(() -> new DeviceTokenNotFoundException(deviceToken.getId()));
         entity.updateFrom(deviceToken);
         return entity.getId();
+    }
+
+    @Override
+    public int deactivateStaleTokens(LocalDateTime threshold) {
+        return deviceTokenJpaRepository.deactivateStaleTokens(
+                threshold, EntityStatus.ACTIVE, EntityStatus.INACTIVE);
     }
 
     @Override

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/repository/DeviceTokenJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/repository/DeviceTokenJpaRepository.java
@@ -3,7 +3,11 @@ package com.personal.marketnote.notification.adapter.out.persistence.device.repo
 import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.notification.adapter.out.persistence.device.entity.DeviceTokenJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +18,17 @@ public interface DeviceTokenJpaRepository extends JpaRepository<DeviceTokenJpaEn
     List<DeviceTokenJpaEntity> findByUserIdAndStatus(Long userId, EntityStatus status);
 
     List<DeviceTokenJpaEntity> findByUserIdInAndStatus(List<Long> userIds, EntityStatus status);
+
+    @Modifying
+    @Query("""
+            UPDATE DeviceTokenJpaEntity d
+            SET d.status = :inactiveStatus
+            WHERE d.lastUsedAt < :threshold
+              AND d.status = :activeStatus
+            """)
+    int deactivateStaleTokens(
+            @Param("threshold") LocalDateTime threshold,
+            @Param("activeStatus") EntityStatus activeStatus,
+            @Param("inactiveStatus") EntityStatus inactiveStatus
+    );
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/device/CleanupStaleDeviceTokensUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/device/CleanupStaleDeviceTokensUseCase.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.notification.port.in.usecase.device;
+
+public interface CleanupStaleDeviceTokensUseCase {
+
+    int cleanupStaleDeviceTokens();
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/device/DeleteDeviceTokenPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/device/DeleteDeviceTokenPort.java
@@ -1,5 +1,9 @@
 package com.personal.marketnote.notification.port.out.device;
 
+import java.time.LocalDateTime;
+
 public interface DeleteDeviceTokenPort {
     void deleteById(Long id);
+
+    int deactivateStaleTokens(LocalDateTime threshold);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/device/CleanupStaleDeviceTokensService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/device/CleanupStaleDeviceTokensService.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.notification.service.device;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.port.in.usecase.device.CleanupStaleDeviceTokensUseCase;
+import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class CleanupStaleDeviceTokensService implements CleanupStaleDeviceTokensUseCase {
+
+    private static final int STALE_DAYS = 90;
+
+    private final DeleteDeviceTokenPort deleteDeviceTokenPort;
+    private final Clock clock;
+
+    @Override
+    public int cleanupStaleDeviceTokens() {
+        LocalDateTime threshold = LocalDateTime.now(clock).minusDays(STALE_DAYS);
+        int deactivatedCount = deleteDeviceTokenPort.deactivateStaleTokens(threshold);
+
+        if (deactivatedCount > 0) {
+            log.info("Stale 디바이스 토큰 정리 완료: {}건 비활성화", deactivatedCount);
+        }
+
+        return deactivatedCount;
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2107

## Task
- [x] CleanupStaleDeviceTokensUseCase + CleanupStaleDeviceTokensService 구현
- [x] DeleteDeviceTokenPort.deactivateStaleTokens 벌크 비활성화 메서드 추가
- [x] DeviceTokenJpaRepository @Modifying 벌크 UPDATE 쿼리 추가
- [x] StaleDeviceTokenCleanupScheduler (cron 매일 04시, @ConditionalOnProperty)
- [x] lastUsedAt 90일 이전 토큰 자동 비활성화
- [x] 정리 결과 로깅
